### PR TITLE
fix(js/version): pre-release tags being used

### DIFF
--- a/assets/js/version.js
+++ b/assets/js/version.js
@@ -1,10 +1,10 @@
-const releasesUrl = 'https://api.github.com/repos/Qbox-project/qbx_core/releases';
+const latestReleaseUrl = 'https://api.github.com/repos/Qbox-project/qbx_core/releases/latest';
 
 async function getLatestRelease() {
     try {
-        const response = await axios.get(releasesUrl);
-        if (response.data && response.data.length > 0) {
-            const latestReleaseVersion = response.data[0].tag_name;
+        const response = await axios.get(latestReleaseUrl);
+        if (response.data) {
+            const latestReleaseVersion = response.data.tag_name;
             document.getElementById('latestRelease').textContent = `${latestReleaseVersion}`;
         } else {
             document.getElementById('latestRelease').textContent = 'v1.0.0';


### PR DESCRIPTION
Fixes pre-releases being used as the latest release tag.